### PR TITLE
Fix image link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ console.log(result);
 
 Output:
 
-![output](https://github.com/fakoua/ink/blob/master/forgit/img01.png)
+![output](forgit/img01.png)
 
 ## String Extension
 
@@ -135,7 +135,7 @@ await ink.drawImage("https://placekitten.com/50/50")
 
 ```
 
-![output](https://github.com/fakoua/ink/blob/master/forgit/img02.png)
+![output](forgit/img02.png)
 
 ## License
 


### PR DESCRIPTION
It's better to use `raw` link or relative link instead of `blob` (which seems only supported by GitHub itself).
See denoland/deno_website2#720.