### PR TITLE
🩹 Allow 'list' as first argument

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -77,7 +77,7 @@ function processArgs(args) {
 }
 
 // CLI
-if (Deno.args.length === 1) {
+if (import.meta.main && Deno.args.length === 1) {
     let cmd = Deno.args[0]
     cmd = cmd.replace("--", "").replace("-", "")
     if (cmd === "list") {


### PR DESCRIPTION
Thank you for this useful lib. I'm using it in a CLI tool.
I suggest a little update to allow 'list' as a first argument in lib dependent modules.